### PR TITLE
Update repo to use docker-compose

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -7,7 +7,7 @@ export TMDB_KEY=
 
 # Mysql DB Creds
 export DB_SEED_FILEPATH=./data/seed-db.sql
-export DB_HOST=host.docker.internal
+export DB_HOST=db
 export DB_NAME=FoD
 export DB_PASS=password
 export DB_USER=root

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,11 @@ setup:
 .PHONY: start
 start: setup
 	@python main.py
+
+.PHONY: start-docker
+start-docker:
+	docker-compose up -d --build
+
+.PHONY: stop-docker
+stop-docker:
+	docker-compose down

--- a/Makefile
+++ b/Makefile
@@ -1,41 +1,23 @@
-.PHONY: build
-build:
-	@docker build -t ${BOT_CONTAINER_NAME} .
-
-.PHONY: db-start
-db-start:
-	@echo "Starting mysql with docker:"
-	@docker run --rm -dit \
-		-p 3306:3306 \
-		-e MYSQL_ROOT_PASSWORD=${DB_PASS} \
-		--name ${DB_CONTAINER_NAME} \
-		mysql:latest
+ifneq (,$(wildcard ./.env))
+    include .env
+    export
+endif
 
 .PHONY: db-mysql
 db-mysql:
-	@docker exec -it $(shell docker ps -aqf name=${DB_CONTAINER_NAME}) \
-		mysql -u${DB_USER} -h${DB_HOST} -p${DB_PASS}
+	@docker-compose exec db mysql -u"${DB_USER}" -p"${DB_PASS}" "${DB_NAME}"
 
 .PHONY: db-bash
 db-bash:
-	@docker exec -it $(shell docker ps -aqf name=${DB_CONTAINER_NAME}) \
-		bash
+	@docker-compose exec db bash
 
 .PHONY: db-dump
 db-dump:
-	@docker exec -it $(shell docker ps -aqf name=${DB_CONTAINER_NAME}) \
-		bash -c 'mysqldump -u${DB_USER} -h${DB_HOST} -p${DB_PASS} -B ${DB_NAME} > /root/${DB_DUMP_FILENAME}'
-	@docker cp $(shell docker ps -aqf name=${DB_CONTAINER_NAME}):/root/${DB_DUMP_FILENAME} ./${DB_DUMP_FILENAME}
+	@docker-compose exec db bash -c 'mysqldump -u"${DB_USER}" -p"${DB_PASS}" -B ${DB_NAME} 2>/dev/null' > ./${DB_DUMP_FILENAME}
 
 .PHONY: db-load
 db-load:
-	@docker cp ./${DB_DUMP_FILENAME} $(shell docker ps -aqf name=${DB_CONTAINER_NAME}):/root/${DB_DUMP_FILENAME}
-	@docker exec -it $(shell docker ps -aqf name=${DB_CONTAINER_NAME}) \
-		bash -c 'mysql -u${DB_USER} -h${DB_HOST} -p${DB_PASS} < /root/${DB_DUMP_FILENAME}'
-
-.PHONY: db-stop
-db-stop:
-	@docker rm -f $(shell docker ps -aqf name=${DB_CONTAINER_NAME})
+	@docker-compose exec -T db sh -c 'exec mysql -u"${DB_USER}" -p"${DB_PASS}" "${DB_NAME}"' < ./${DB_DUMP_FILENAME}
 
 .PHONY: setup
 setup:
@@ -44,12 +26,3 @@ setup:
 .PHONY: start
 start: setup
 	@python main.py
-
-.PHONY: start-docker
-start-docker:
-	@docker run --rm -it \
-		--name ${BOT_CONTAINER_NAME} \
-		-v ${PWD}:/bot \
-		-w /bot \
-		${BOT_CONTAINER_NAME}
-

--- a/README.md
+++ b/README.md
@@ -13,16 +13,7 @@ git clone https://github.com/jp00p/FoDBot-SQL.git && cd FoDBot-SQL
 # Fill out .env vars...
 cp .env-example .env
 
-# Start mysql container (~30 second startup time)
-make db-start
-
-# (optional) Load sql dump into database
-make db-load
-
-# Build local container to run bot in
-make build
-
-# Start bot (ctrl+c to stop)
+# Build and start the docker containers
 make start-docker
 
 # Mysql session with database
@@ -34,8 +25,11 @@ make db-bash
 # Mysql dump to file
 make db-dump
 
-# Stop mysql container
-make db-stop
+# Mysql load from a file
+make db-load
+
+# Stop the containers
+make stop-docker
 
 # Blatent cheating
 UPDATE users SET score=42069, spins=420, jackpots=69, wager=25, high_roller=1 WHERE id=1;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.8"
+services:
+  app:
+    image: ${BOT_CONTAINER_NAME:-fodbot}:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/bot
+    working_dir: /bot
+    restart: on-failure
+  db:
+    image: mysql:latest
+    environment:
+      - MYSQL_DATABASE=${DB_NAME:-FoD}
+      - MYSQL_ROOT_PASSWORD=${DB_ROOT_PASSWORD:-password}
+    ports:
+      - 3306:3306
+    volumes:
+      - ./data/seed-db.sql:/docker-entrypoint-initdb.d/seed-db.sql
+      - .:/bot


### PR DESCRIPTION
With these changes, you can start the project with `docker-compose up` and it should automatically pull or build the images and start them up.  Use `docker-compose down` to stop them.  As it stands right now, the `app` service running the bot will restart several times while the database service starts up.  Once the database is ready, the app will start up normally.  To follow the logs from the services, use `docker-compose logs -f`.